### PR TITLE
Add scroll-padding-top to style.css

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -1,4 +1,8 @@
 /* Add your own CSS here to build on top of Simple.css */
+html {
+  scroll-padding-top: 2rem;
+}
+
 header h1 {
   padding-top: 2rem;
 }


### PR DESCRIPTION
When the "Hall of Fame" button at the top is pressed, the page scrolls down and leaves no space above the "Hall of fame" heading (i.e. between the top edge of the heading text and the top edge of the viewport). With this property the page scrolls down and leaves 2rem space above the heading.