### PR TITLE
Add DanQ.me × 4 to Hall of Fame

### DIFF
--- a/_data/halloffame.yml
+++ b/_data/halloffame.yml
@@ -95,6 +95,10 @@
   link: https://simbly.me
   date-completed: April 2021
 
+- name: Dan Q (×4)
+  link: https://danq.me
+  date-completed: December 2020
+
 - name: Khürt Williams
   link: https://islandinthenet.com
   date-completed: December 2020

--- a/_data/halloffame.yml
+++ b/_data/halloffame.yml
@@ -14,6 +14,10 @@
   link: https://jacksonchen666.com
   date-completed: October 2023
 
+- name: Dan Q (×4)
+  link: https://danq.me
+  date-completed: August 2023
+
 - name: Fredrik Björeman
   link: https://www.bjoreman.com
   date-completed: August 2023
@@ -94,10 +98,6 @@
 - name: "Thumb"
   link: https://simbly.me
   date-completed: April 2021
-
-- name: Dan Q (×4)
-  link: https://danq.me
-  date-completed: December 2020
 
 - name: Khürt Williams
   link: https://islandinthenet.com


### PR DESCRIPTION
After [some musing](https://danq.me/2024/02/05/100-days-to-offload/) and a discussion with @kevquirk, we've agreed that I successfully completed the challenge in December 2020, August 2021, October 2022, and August 2023: each of four calendar years!

This PR adds me to the Hall of Fame.