### PR TITLE
Move Michał Sapka's domain

### DIFF
--- a/_data/halloffame.yml
+++ b/_data/halloffame.yml
@@ -39,7 +39,7 @@
   date-completed: September 2024
 
 - name: Michał Sapka
-  link: https://michal.sapka.me
+  link: https://michal.sapka.pl
   date-completed: July 2024
 
 - name: Stefan Alfbo
@@ -194,3 +194,4 @@
 - name: Robert Winter
   link: https://robert.winter.ink
   date-completed: August 2020
+


### PR DESCRIPTION
Michał Sapka's site has moved. He used to have redirection in place, but the SSL certificate has expired on the redirection. The domain should probably be updated.